### PR TITLE
Conditionally depend on Windows and Unix libraries.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ repository = "https://github.com/softprops/atty"
 keywords = ["terminal", "tty"]
 license = "MIT"
 
-[dependencies]
+[target.'cfg(unix)'.dependencies]
 libc = "0.2"
+
+[target.'cfg(windows)'.dependencies]
 winapi = "0.2"
 kernel32-sys = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,6 @@
 //! }
 //! ```
 
-extern crate libc;
-
 /// possible stream sources
 pub enum Stream {
     Stdout,
@@ -27,6 +25,8 @@ pub enum Stream {
 /// returns true if this is a tty
 #[cfg(unix)]
 pub fn is(stream: Stream) -> bool {
+    extern crate libc;
+
     let fd = match stream {
         Stream::Stdout => libc::STDOUT_FILENO,
         Stream::Stderr => libc::STDERR_FILENO,


### PR DESCRIPTION
Avoid pulling in WinAPI crates on Unix and vice versa.

Reference:
http://doc.crates.io/specifying-dependencies.html#platform-specific-dependencies