### PR TITLE
Use target specific dependencies.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
     - rust: nightly
     - rust: beta
     - rust: stable
+    - rust: 1.8.0
 os:
  - linux
  - osx

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ repository = "https://github.com/softprops/atty"
 keywords = ["terminal", "tty"]
 license = "MIT"
 
-[dependencies]
+[target.'cfg(not(windows))'.dependencies]
 libc = "0.2"
-winapi = "0.2"
+
+[target.'cfg(windows)'.dependencies]
 kernel32-sys = "0.2"
+winapi = "0.2"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   - TARGET: nightly-i686-pc-windows-msvc
   - TARGET: nightly-x86_64-pc-windows-gnu
   - TARGET: nightly-i686-pc-windows-gnu
-  - TARGET: 1.6.0-x86_64-pc-windows-gnu
+  - TARGET: 1.8.0-x86_64-pc-windows-gnu
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-${env:TARGET}.exe" -FileName "rust-install.exe"
   - ps: .\rust-install.exe /VERYSILENT /NORESTART /DIR="C:\rust" | Out-Null

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,6 @@
 //! }
 //! ```
 
-extern crate libc;
-
 /// possible stream sources
 pub enum Stream {
     Stdout,
@@ -27,6 +25,8 @@ pub enum Stream {
 /// returns true if this is a tty
 #[cfg(unix)]
 pub fn is(stream: Stream) -> bool {
+    extern crate libc;
+
     let fd = match stream {
         Stream::Stdout => libc::STDOUT_FILENO,
         Stream::Stderr => libc::STDERR_FILENO,
@@ -93,12 +93,25 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
+    fn is_err() {
+        assert!(is(Stream::Stderr))
+    }
+
+    #[test]
+    #[cfg(unix)]
     fn is_out() {
         assert!(is(Stream::Stdout))
     }
 
     #[test]
-    #[cfg(unix)]
+    #[cfg(target_os = "macos")]
+    fn is_in() {
+        // macos on travis seems to pipe its input
+        assert!(!is(Stream::Stdin))
+    }
+
+    #[test]
+    #[cfg(all(not(target_os = "macos"), unix))]
     fn is_in() {
         assert!(is(Stream::Stdin))
     }


### PR DESCRIPTION
This commit changes the Cargo.toml to require winapi and kernel32 only
on Windows builds, and requires libc for all other builds.