### PR TITLE
disable libc default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["terminal", "tty"]
 license = "MIT"
 
 [target.'cfg(not(windows))'.dependencies]
-libc = "0.2"
+libc = { version = "0.2", default-features = false }
 
 [target.'cfg(windows)'.dependencies]
 kernel32-sys = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,8 @@
 //! }
 //! ```
 
+#![cfg_attr(not(windows), no_std)]
+
 #[cfg(windows)]
 extern crate kernel32;
 #[cfg(not(windows))]


### PR DESCRIPTION
So the crate can also be used in in a `#![no_std]` situation.