### PR TITLE
Fix an inverted condition on MinGW

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ unsafe fn msys_tty_on(fd: DWORD) -> bool {
         name_info_bytes.len() as u32,
     );
     if res == 0 {
-        return true;
+        return false;
     }
     let name_info: FILE_NAME_INFO = *(name_info_bytes[0..size].as_ptr() as
                                           *const FILE_NAME_INFO);


### PR DESCRIPTION
I was reading over this crate a bit and found this (didn't actually run into it
in the wild), but it seems like the intention here may have been to return
`false` (aka not a tty) if `GetFileInformationByHandleEx` failed!