### PR TITLE
Change `||` to `&&` for whether MSYS is a tty

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ unsafe fn msys_tty_on(fd: DWORD) -> bool {
         .as_os_str()
         .to_string_lossy()
         .into_owned();
-    name.contains("msys-") || name.contains("-pty")
+    name.contains("msys-") && name.contains("-pty")
 }
 
 /// returns true if this is a tty


### PR DESCRIPTION
The MSYS terminal appears to create pipes with the name `msys-` but *don't*
contain `-pty`, so this changes the `||` logic to `&&` to ensure that the logic
here doesn't fire for MSYS terminals where piping is used to erroneously
diagnose a stdio stream as a tty.

Closes #23