### PR TITLE
Problem: atty won't compile for wasm32-unknown-emscripten target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub enum Stream {
 }
 
 /// returns true if this is a tty
-#[cfg(unix)]
+#[cfg(all(unix, not(target_arch = "wasm32")))]
 pub fn is(stream: Stream) -> bool {
     extern crate libc;
 


### PR DESCRIPTION
```
40  | pub fn is(stream: Stream) -> bool {
    | --------------------------------- previous definition of the value `is` here
    ...
164 | pub fn is(_stream: Stream) -> bool {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `is` redefined here
    |
```

Solution: exclude the first line against this target