### PR TITLE
Add doc-comment to test README examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ features = ["consoleapi", "processenv", "minwinbase", "minwindef", "winbase"]
 
 [target.'cfg(target_os = "redox")'.dependencies]
 termion = "1.5"
+
+[dev-dependencies]
+doc-comment = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,12 @@ extern crate libc;
 extern crate winapi;
 #[cfg(target_os = "redox")]
 extern crate termion;
+#[cfg(test)]
+#[macro_use]
+extern crate doc_comment;
+
+#[cfg(test)]
+doctest!("../README.md");
 
 #[cfg(windows)]
 use winapi::shared::minwindef::DWORD;


### PR DESCRIPTION
Allows to keep in check the README file examples.