### PR TITLE
Bring back support for redox in the current setup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,3 @@ libc = { version = "0.2", default-features = false }
 version = "0.3"
 features = ["consoleapi", "processenv", "minwinbase", "minwindef", "winbase"]
 
-[target.'cfg(target_os = "redox")'.dependencies]
-termion = "1.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,6 @@
 extern crate libc;
 #[cfg(windows)]
 extern crate winapi;
-#[cfg(target_os = "redox")]
-extern crate termion;
 
 #[cfg(windows)]
 use winapi::shared::minwindef::DWORD;
@@ -138,19 +136,6 @@ unsafe fn msys_tty_on(fd: DWORD) -> bool {
     let is_msys = name.contains("msys-") || name.contains("cygwin-");
     let is_pty = name.contains("-pty");
     is_msys && is_pty
-}
-
-/// returns true if this is a tty
-#[cfg(target_os = "redox")]
-pub fn is(stream: Stream) -> bool {
-    use std::io;
-    use termion::is_tty;
-
-    match stream {
-        Stream::Stdin => is_tty(&io::stdin()),
-        Stream::Stdout => is_tty(&io::stdout()),
-        Stream::Stderr => is_tty(&io::stderr()),
-    }
 }
 
 /// returns true if this is a tty


### PR DESCRIPTION
Redox is now in the unix family, so there was a comflict with cfgs
Redox now implements the isatty function in libc