### PR TITLE
add support of the unikernel RustyHermit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ travis-ci = { repository = "softprops/atty" }
 [target.'cfg(unix)'.dependencies]
 libc = { version = "0.2", default-features = false }
 
+[target.'cfg(target_os = "hermit")'.dependencies]
+hermit-abi = "0.1.6"
+
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"
 features = ["consoleapi", "processenv", "minwinbase", "minwindef", "winbase"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,19 @@ pub fn is(stream: Stream) -> bool {
 }
 
 /// returns true if this is a tty
+#[cfg(target_os = "hermit")]
+pub fn is(stream: Stream) -> bool {
+    extern crate hermit_abi;
+
+    let fd = match stream {
+        Stream::Stdout => hermit_abi::STDOUT_FILENO,
+        Stream::Stderr => hermit_abi::STDERR_FILENO,
+        Stream::Stdin => hermit_abi::STDIN_FILENO,
+    };
+    hermit_abi::isatty(fd)
+}
+
+/// returns true if this is a tty
 #[cfg(windows)]
 pub fn is(stream: Stream) -> bool {
     use winapi::um::winbase::{


### PR DESCRIPTION
We are developing the unikernel RustyHermit (https://github.com/hermitcore/libhermit-rs), where the kernel is written in Rust and is already part of the Rust Standard Library. With this pull request, we want to integrate our interface to determine the number of CPUs.