### PR TITLE
Blanket implementations for usual I/O structures

### DIFF
--- a/examples/trait.rs
+++ b/examples/trait.rs
@@ -7,18 +7,27 @@ fn main() {
     let stdout = std::io::stdout();
     let stderr = std::io::stderr();
     let file   = std::fs::File::open("LICENSE").unwrap();
-    #[cfg(unix)]
     let tcp    = std::net::TcpStream::connect("1.1.1.1:80").unwrap();
 
-    println!("{:<25} - {}", "std::io::Stdin",  stdin.isatty());
-    println!("{:<25} - {}", "std::io::Stdout", stdout.isatty());
-    println!("{:<25} - {}", "std::io::Stderr", stderr.isatty());
-    println!("{:<25} - {}", "std::fs::File",   file.isatty());
-    #[cfg(unix)]
+    println!("{:<25} - {}", "std::io::Stdin",      stdin.isatty());
+    println!("{:<25} - {}", "std::io::Stdout",     stdout.isatty());
+    println!("{:<25} - {}", "std::io::Stderr",     stderr.isatty());
+    println!("{:<25} - {}", "std::fs::File",       file.isatty());
     println!("{:<25} - {}", "std::net::TcpStream", tcp.isatty());
 
     println!("\ndyn trait Example:");
-    let all : Vec<Box<dyn IsATTY>> = vec![Box::new(stderr), Box::new(file)];
+    let all : Vec<Box<dyn IsATTY<_>>> = vec![
+        Box::new(stdin),
+        Box::new(stdout),
+        Box::new(stderr),
+        Box::new(file),
+        // The following is not possible on windows because, as the IsATTY trait was
+        // implemented, the boxed type signatures differ:
+        // Box<dyn IsATTY<SOCKET>> vs Box<dyn IsATTY<HANDLE>>
+        #[cfg(unix)]
+        Box::new(tcp)
+        ];
+
     for (i, b) in all.into_iter().enumerate() {
         println!("element #{} : {}", i, b.isatty());
     }

--- a/examples/trait.rs
+++ b/examples/trait.rs
@@ -3,20 +3,20 @@ extern crate atty;
 use atty::IsATTY;
 
 fn main() {
-    let stdin  = std::io::stdin();
+    let stdin = std::io::stdin();
     let stdout = std::io::stdout();
     let stderr = std::io::stderr();
-    let file   = std::fs::File::open("LICENSE").unwrap();
-    let tcp    = std::net::TcpStream::connect("1.1.1.1:80").unwrap();
+    let file = std::fs::File::open("LICENSE").unwrap();
+    let tcp = std::net::TcpStream::connect("1.1.1.1:80").unwrap();
 
-    println!("{:<25} - {}", "std::io::Stdin",      stdin.isatty());
-    println!("{:<25} - {}", "std::io::Stdout",     stdout.isatty());
-    println!("{:<25} - {}", "std::io::Stderr",     stderr.isatty());
-    println!("{:<25} - {}", "std::fs::File",       file.isatty());
+    println!("{:<25} - {}", "std::io::Stdin", stdin.isatty());
+    println!("{:<25} - {}", "std::io::Stdout", stdout.isatty());
+    println!("{:<25} - {}", "std::io::Stderr", stderr.isatty());
+    println!("{:<25} - {}", "std::fs::File", file.isatty());
     println!("{:<25} - {}", "std::net::TcpStream", tcp.isatty());
 
     println!("\ndyn trait Example:");
-    let all : Vec<Box<dyn IsATTY<_>>> = vec![
+    let all: Vec<Box<dyn IsATTY<_>>> = vec![
         Box::new(stdin),
         Box::new(stdout),
         Box::new(stderr),
@@ -25,8 +25,8 @@ fn main() {
         // implemented, the boxed type signatures differ:
         // Box<dyn IsATTY<SOCKET>> vs Box<dyn IsATTY<HANDLE>>
         #[cfg(unix)]
-        Box::new(tcp)
-        ];
+        Box::new(tcp),
+    ];
 
     for (i, b) in all.into_iter().enumerate() {
         println!("element #{} : {}", i, b.isatty());

--- a/examples/trait.rs
+++ b/examples/trait.rs
@@ -1,0 +1,25 @@
+extern crate atty;
+
+use atty::IsATTY;
+
+fn main() {
+    let stdin  = std::io::stdin();
+    let stdout = std::io::stdout();
+    let stderr = std::io::stderr();
+    let file   = std::fs::File::open("LICENSE").unwrap();
+    #[cfg(unix)]
+    let tcp    = std::net::TcpStream::connect("1.1.1.1:80").unwrap();
+
+    println!("{:<25} - {}", "std::io::Stdin",  stdin.isatty());
+    println!("{:<25} - {}", "std::io::Stdout", stdout.isatty());
+    println!("{:<25} - {}", "std::io::Stderr", stderr.isatty());
+    println!("{:<25} - {}", "std::fs::File",   file.isatty());
+    #[cfg(unix)]
+    println!("{:<25} - {}", "std::net::TcpStream", tcp.isatty());
+
+    println!("\ndyn trait Example:");
+    let all : Vec<Box<dyn IsATTY>> = vec![Box::new(stderr), Box::new(file)];
+    for (i, b) in all.into_iter().enumerate() {
+        println!("element #{} : {}", i, b.isatty());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,9 @@ extern crate winapi;
 #[cfg(windows)]
 use winapi::shared::ntdef::WCHAR;
 #[cfg(windows)]
-use winapi::um::winnt::HANDLE;
+use winapi::um::winbase::{STD_ERROR_HANDLE, STD_INPUT_HANDLE, STD_OUTPUT_HANDLE};
 #[cfg(windows)]
-use winapi::um::winbase::{STD_ERROR_HANDLE,STD_INPUT_HANDLE,STD_OUTPUT_HANDLE};
+use winapi::um::winnt::HANDLE;
 
 /// possible stream sources
 #[derive(Clone, Copy, Debug)]
@@ -54,10 +54,10 @@ pub fn is(stream: Stream) -> bool {
 }
 
 #[cfg(all(unix, not(target_arch = "wasm32")))]
-impl<T:std::os::unix::io::AsRawFd> IsATTY<std::os::unix::io::RawFd> for T {
+impl<T: std::os::unix::io::AsRawFd> IsATTY<std::os::unix::io::RawFd> for T {
     fn isatty(&self) -> bool {
         extern crate libc;
-        unsafe { libc::isatty(self.as_raw_fd()) != 0}
+        unsafe { libc::isatty(self.as_raw_fd()) != 0 }
     }
 }
 
@@ -75,7 +75,7 @@ pub fn is(stream: Stream) -> bool {
 }
 
 #[cfg(target_os = "hermit")]
-impl<T:std::os::unix::io::AsRawFd> IsATTY<std::os::unix::io::RawFd> for T {
+impl<T: std::os::unix::io::AsRawFd> IsATTY<std::os::unix::io::RawFd> for T {
     fn isatty(&self) -> bool {
         extern crate hermit_abi;
         hermit_abi::isatty(self.as_raw_fd())
@@ -86,26 +86,26 @@ impl<T:std::os::unix::io::AsRawFd> IsATTY<std::os::unix::io::RawFd> for T {
 #[cfg(windows)]
 pub fn is(stream: Stream) -> bool {
     use winapi::um::processenv::GetStdHandle;
-    let stdin = unsafe {GetStdHandle(STD_INPUT_HANDLE)};
-    let stdout = unsafe {GetStdHandle(STD_OUTPUT_HANDLE)};
-    let stderr = unsafe {GetStdHandle(STD_ERROR_HANDLE)};
+    let stdin = unsafe { GetStdHandle(STD_INPUT_HANDLE) };
+    let stdout = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) };
+    let stderr = unsafe { GetStdHandle(STD_ERROR_HANDLE) };
     let (handle, others) = match stream {
         Stream::Stdin => (stdin, [stderr, stdout]),
         Stream::Stderr => (stderr, [stdin, stdout]),
         Stream::Stdout => (stdout, [stdin, stderr]),
     };
-    
+
     is_handle_a_tty(&handle, &others)
 }
 
 #[cfg(windows)]
-impl<T:std::os::windows::io::AsRawHandle> IsATTY<std::os::windows::io::RawHandle> for T {
+impl<T: std::os::windows::io::AsRawHandle> IsATTY<std::os::windows::io::RawHandle> for T {
     fn isatty(&self) -> bool {
         use winapi::um::processenv::GetStdHandle;
         let handle = self.as_raw_handle() as HANDLE;
-        let stdin = unsafe {GetStdHandle(STD_INPUT_HANDLE)};
-        let stdout = unsafe {GetStdHandle(STD_OUTPUT_HANDLE)};
-        let stderr = unsafe {GetStdHandle(STD_ERROR_HANDLE)};
+        let stdin = unsafe { GetStdHandle(STD_INPUT_HANDLE) };
+        let stdout = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) };
+        let stderr = unsafe { GetStdHandle(STD_ERROR_HANDLE) };
         let others = [stdin, stdout, stderr];
 
         is_handle_a_tty(&handle, &others)
@@ -113,7 +113,7 @@ impl<T:std::os::windows::io::AsRawHandle> IsATTY<std::os::windows::io::RawHandle
 }
 
 #[cfg(windows)]
-impl<T:std::os::windows::io::AsRawSocket> IsATTY<std::os::windows::io::RawSocket> for T {
+impl<T: std::os::windows::io::AsRawSocket> IsATTY<std::os::windows::io::RawSocket> for T {
     fn isatty(&self) -> bool {
         false
     }
@@ -150,7 +150,7 @@ pub fn isnt(stream: Stream) -> bool {
 /// Returns true if any of the given fds are on a console.
 #[cfg(windows)]
 unsafe fn console_on(handle: &HANDLE) -> bool {
-    use winapi::um::{consoleapi::GetConsoleMode};
+    use winapi::um::consoleapi::GetConsoleMode;
 
     let mut out = 0;
     if GetConsoleMode(*handle, &mut out) != 0 {
@@ -206,7 +206,7 @@ pub fn is(_stream: Stream) -> bool {
 }
 
 #[cfg(target_arch = "wasm32")]
-impl<T:std::os::unix::io::AsRawFd> IsATTY for T {
+impl<T: std::os::unix::io::AsRawFd> IsATTY for T {
     fn isatty(&self) -> bool {
         false
     }
@@ -214,7 +214,7 @@ impl<T:std::os::unix::io::AsRawFd> IsATTY for T {
 
 #[cfg(test)]
 mod tests {
-    use super::{is, Stream, IsATTY};
+    use super::{is, IsATTY, Stream};
 
     #[test]
     #[cfg(windows)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,12 +21,11 @@ extern crate libc;
 extern crate winapi;
 
 #[cfg(windows)]
-use winapi::shared::ntdef::{WCHAR, HANDLE};
+use winapi::shared::ntdef::WCHAR;
 #[cfg(windows)]
-use winapi::um::winbase::{
-    STD_ERROR_HANDLE as STD_ERROR, STD_INPUT_HANDLE as STD_INPUT,
-    STD_OUTPUT_HANDLE as STD_OUTPUT,
-};
+use winapi::um::winnt::HANDLE;
+#[cfg(windows)]
+use winapi::um::winbase::{STD_ERROR_HANDLE,STD_INPUT_HANDLE,STD_OUTPUT_HANDLE};
 
 /// possible stream sources
 #[derive(Clone, Copy, Debug)]
@@ -87,9 +86,9 @@ impl<T:std::os::unix::io::AsRawFd> IsATTY<std::os::unix::io::RawFd> for T {
 #[cfg(windows)]
 pub fn is(stream: Stream) -> bool {
     use winapi::um::processenv::GetStdHandle;
-    let stdin = unsafe {GetStdHandle(STD_INPUT) as HANDLE};
-    let stdout = unsafe {GetStdHandle(STD_OUTPUT) as HANDLE};
-    let stderr = unsafe {GetStdHandle(STD_ERROR) as HANDLE};
+    let stdin = unsafe {GetStdHandle(STD_INPUT_HANDLE)};
+    let stdout = unsafe {GetStdHandle(STD_OUTPUT_HANDLE)};
+    let stderr = unsafe {GetStdHandle(STD_ERROR_HANDLE)};
     let (handle, others) = match stream {
         Stream::Stdin => (stdin, [stderr, stdout]),
         Stream::Stderr => (stderr, [stdin, stdout]),
@@ -104,9 +103,9 @@ impl<T:std::os::windows::io::AsRawHandle> IsATTY<std::os::windows::io::RawHandle
     fn isatty(&self) -> bool {
         use winapi::um::processenv::GetStdHandle;
         let handle = self.as_raw_handle() as HANDLE;
-        let stdin = unsafe {GetStdHandle(STD_INPUT) as HANDLE};
-        let stdout = unsafe {GetStdHandle(STD_OUTPUT) as HANDLE};
-        let stderr = unsafe {GetStdHandle(STD_ERROR) as HANDLE};
+        let stdin = unsafe {GetStdHandle(STD_INPUT_HANDLE)};
+        let stdout = unsafe {GetStdHandle(STD_OUTPUT_HANDLE)};
+        let stderr = unsafe {GetStdHandle(STD_ERROR_HANDLE)};
         let others = [stdin, stdout, stderr];
 
         is_handle_a_tty(&handle, &others)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,7 @@ pub enum Stream {
 }
 
 pub trait IsATTY<T> {
+    /// test whether this structure refers to a terminal
     fn isatty(&self) -> bool;
 }
 
@@ -214,50 +215,57 @@ impl<T:std::os::unix::io::AsRawFd> IsATTY for T {
 
 #[cfg(test)]
 mod tests {
-    use super::{is, Stream};
+    use super::{is, Stream, IsATTY};
 
     #[test]
     #[cfg(windows)]
     fn is_err() {
         // appveyor pipes its output
-        assert!(!is(Stream::Stderr))
+        assert!(!is(Stream::Stderr));
+        assert!(!std::io::stderr().isatty());
     }
 
     #[test]
     #[cfg(windows)]
     fn is_out() {
         // appveyor pipes its output
-        assert!(!is(Stream::Stdout))
+        assert!(!is(Stream::Stdout));
+        assert!(!std::io::stdout().isatty());
     }
 
     #[test]
     #[cfg(windows)]
     fn is_in() {
-        assert!(is(Stream::Stdin))
+        assert!(is(Stream::Stdin));
+        assert!(std::io::stdin().isatty());
     }
 
     #[test]
     #[cfg(unix)]
     fn is_err() {
-        assert!(is(Stream::Stderr))
+        assert!(is(Stream::Stderr));
+        assert!(std::io::stderr().isatty());
     }
 
     #[test]
     #[cfg(unix)]
     fn is_out() {
-        assert!(is(Stream::Stdout))
+        assert!(is(Stream::Stdout));
+        assert!(std::io::stdout().isatty());
     }
 
     #[test]
     #[cfg(target_os = "macos")]
     fn is_in() {
         // macos on travis seems to pipe its input
-        assert!(is(Stream::Stdin))
+        assert!(is(Stream::Stdin));
+        assert!(std::io::stdin().isatty());
     }
 
     #[test]
     #[cfg(all(not(target_os = "macos"), unix))]
     fn is_in() {
-        assert!(is(Stream::Stdin))
+        assert!(is(Stream::Stdin));
+        assert!(std::io::stdin().isatty());
     }
 }


### PR DESCRIPTION
My attempt at implementing #20 

Python I/O objects usually have a `isatty()` method:
```python
file = open("foo.txt", "wb")
ret = file.isatty()
```

This PR mirrors that functionality by adding a trait containing that function, along with blanket implementations for `AsRawFD` (unix) and `AsRawHandle`+`AsRawSocket` (windows). This would allow the following:

```rust
use atty::IsATTY;

fn main() {
    let file = std::fs::File::open("foo.txt").unwrap();
    let ret = file.isatty();
}
```

As far as I can tell, the names I've picked for the trait and method might break naming conventions. I'd appreciate some input on whether the naming should be changed.