### PR TITLE
Add support for SGX (using the x86_64-fortanix-unknown-sgx target)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ unsafe fn msys_tty_on(fd: DWORD) -> bool {
 }
 
 /// returns true if this is a tty
-#[cfg(target_arch = "wasm32")]
+#[cfg(any(target_arch = "wasm32", target_env = "sgx"))]
 pub fn is(_stream: Stream) -> bool {
     false
 }


### PR DESCRIPTION
Supports the `x86_64-fortanix-unknown-sgx` target by just returning `false` the same as the `wasm32` targets.