### PR TITLE
Support SOLID targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ unsafe fn msys_tty_on(fd: DWORD) -> bool {
 }
 
 /// returns true if this is a tty
-#[cfg(any(target_arch = "wasm32", target_env = "sgx"))]
+#[cfg(any(target_arch = "wasm32", target_env = "sgx", target_os = "solid_asp3"))]
 pub fn is(_stream: Stream) -> bool {
     false
 }


### PR DESCRIPTION
Supports [the SOLID targets](https://doc.rust-lang.org/1.61.0/rustc/platform-support/kmc-solid.html) (`*-kmc-solid_*`) just by returning `false` similarly to the SGX and `wasm32` targets.