### PR TITLE
Switch from winapi to windows-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ libc = { version = "0.2", default-features = false }
 [target.'cfg(target_os = "hermit")'.dependencies]
 hermit-abi = "0.1.6"
 
-[target.'cfg(windows)'.dependencies.winapi]
-version = "0.3"
-features = ["consoleapi", "processenv", "minwinbase", "minwindef", "winbase"]
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.42"
+features = ["Win32_System_Console", "Win32_Foundation", "Win32_Storage_FileSystem"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,12 +20,10 @@
 #[cfg(unix)]
 extern crate libc;
 #[cfg(windows)]
-extern crate winapi;
+extern crate windows_sys;
 
 #[cfg(windows)]
-use winapi::shared::minwindef::DWORD;
-#[cfg(windows)]
-use winapi::shared::ntdef::WCHAR;
+use windows_sys::Win32::System::Console::STD_HANDLE;
 
 /// possible stream sources
 #[derive(Clone, Copy, Debug)]
@@ -64,7 +62,7 @@ pub fn is(stream: Stream) -> bool {
 /// returns true if this is a tty
 #[cfg(windows)]
 pub fn is(stream: Stream) -> bool {
-    use winapi::um::winbase::{
+    use windows_sys::Win32::System::Console::{
         STD_ERROR_HANDLE as STD_ERROR, STD_INPUT_HANDLE as STD_INPUT,
         STD_OUTPUT_HANDLE as STD_OUTPUT,
     };
@@ -100,8 +98,8 @@ pub fn isnt(stream: Stream) -> bool {
 
 /// Returns true if any of the given fds are on a console.
 #[cfg(windows)]
-unsafe fn console_on_any(fds: &[DWORD]) -> bool {
-    use winapi::um::{consoleapi::GetConsoleMode, processenv::GetStdHandle};
+unsafe fn console_on_any(fds: &[STD_HANDLE]) -> bool {
+    use windows_sys::Win32::System::Console::{GetConsoleMode, GetStdHandle};
 
     for &fd in fds {
         let mut out = 0;
@@ -115,20 +113,18 @@ unsafe fn console_on_any(fds: &[DWORD]) -> bool {
 
 /// Returns true if there is an MSYS tty on the given handle.
 #[cfg(windows)]
-unsafe fn msys_tty_on(fd: DWORD) -> bool {
+unsafe fn msys_tty_on(fd: STD_HANDLE) -> bool {
     use std::{mem, slice};
 
-    use winapi::{
-        ctypes::c_void,
-        shared::minwindef::MAX_PATH,
-        um::{
-            fileapi::FILE_NAME_INFO, minwinbase::FileNameInfo, processenv::GetStdHandle,
-            winbase::GetFileInformationByHandleEx,
-        },
+    use std::ffi::c_void;
+    use windows_sys::Win32::{
+        Foundation::MAX_PATH,
+        Storage::FileSystem::{FileNameInfo, GetFileInformationByHandleEx, FILE_NAME_INFO},
+        System::Console::GetStdHandle,
     };
 
     let size = mem::size_of::<FILE_NAME_INFO>();
-    let mut name_info_bytes = vec![0u8; size + MAX_PATH * mem::size_of::<WCHAR>()];
+    let mut name_info_bytes = vec![0u8; size + (MAX_PATH as usize) * mem::size_of::<u16>()];
     let res = GetFileInformationByHandleEx(
         GetStdHandle(fd),
         FileNameInfo,


### PR DESCRIPTION
The `winapi` crate has not been updated in two years. The replacement is `windows-sys`.

Testing: compiled with old `rustc` (1.39.0)
Build performance: compilation time improved from `4.2 sec` to `3.1 sec`.