### PR TITLE
lib: add support for xous

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,7 @@ unsafe fn msys_tty_on(fd: DWORD) -> bool {
 }
 
 /// returns true if this is a tty
-#[cfg(any(target_arch = "wasm32", target_env = "sgx"))]
+#[cfg(any(target_arch = "wasm32", target_env = "sgx", target_os = "xous"))]
 pub fn is(_stream: Stream) -> bool {
     false
 }


### PR DESCRIPTION
Add support for riscv32imac-unknown-xous-elf, which does not support ttys.