### PR TITLE
increase version number of hermit-abi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ travis-ci = { repository = "softprops/atty" }
 libc = { version = "0.2", default-features = false }
 
 [target.'cfg(target_os = "hermit")'.dependencies]
-hermit-abi = "0.1.6"
+hermit-abi = "0.3"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"


### PR DESCRIPTION
RustHermit publishes a new ABI, which isn't completely backward compatible. For `atty` are these changes not important. However, I wrote a PR to update `atty`  to avoid that `std` includes all different ABI versions.

See also https://github.com/rust-lang/rust/pull/107405